### PR TITLE
bug: fix error if hotkey is missing current system

### DIFF
--- a/internal/luaformatter/formatter.go
+++ b/internal/luaformatter/formatter.go
@@ -161,7 +161,8 @@ func (formatter *Formatter) Format(hotkeys []*izu.Hotkey) ([]string, error) {
 		} else if scommand, ok := hotkey.Command["default"]; ok {
 			command = scommand
 		} else {
-			return nil, fmt.Errorf("no command found for hotkey '%s' on system '%s'", hotkey.String(), formatter.system)
+			slog.Warn("No command found for hotkey", "hotkey", hotkey.String(), "system", formatter.system)
+			continue
 		}
 
 		// format the command part of this hotkey

--- a/izu-generate.nix
+++ b/izu-generate.nix
@@ -17,7 +17,7 @@ pkgs.stdenv.mkDerivation {
   phases = "installPhase";
 
   installPhase = ''
-    izu --config ${cfg} --formatter ${formatter} > "$out"
+    izu --silent --config ${cfg} --formatter ${formatter} > "$out"
   '';
 
   meta = {


### PR DESCRIPTION
**Description**
Whenever a hotkey does not have a default or the current system, send a warning instead of an error and continue

Also add silent output to the nixGenerate function to prevent warnings to show up in the output

**Related issues**
Fixes #6 

**Checklist**
- [x] Tested:
  - `go test ./...` succeeds
  - `nix build` succeeds
- [x] Formatted using [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)
- [ ] VERSION file has been updated using [semver](https://semver.org/)
